### PR TITLE
Container images update

### DIFF
--- a/examples/container/cxi-base/Containerfile
+++ b/examples/container/cxi-base/Containerfile
@@ -1,0 +1,98 @@
+FROM docker.io/nvidia/cuda:12.8.0-devel-ubuntu24.04
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive \
+       apt-get install -y \
+        build-essential \
+        ca-certificates \
+        pkg-config \
+        automake \
+        autoconf \
+        libtool \
+        cmake \
+        gdb \
+        strace \
+        wget \
+        git \
+        bzip2 \
+        python3 \
+        rdma-core \
+        numactl \
+        libconfig-dev \
+        libuv1-dev \
+        libfuse-dev \
+        libfuse3-dev \
+        libyaml-dev \
+        libnl-3-dev \
+        libnuma-dev \
+        libsensors-dev \
+        libcurl4-openssl-dev \
+        libjson-c-dev \
+        libibverbs-dev \
+        --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG GDRCOPY_VER=2.4.4
+RUN git clone --depth 1 --branch v${GDRCOPY_VER} https://github.com/NVIDIA/gdrcopy.git \
+    && cd gdrcopy \
+    && export CUDA_PATH=${CUDA_HOME:-$(echo $(which nvcc) | grep -o '.*cuda')} \
+    && make CC=gcc CUDA=$CUDA_PATH lib \
+    && make lib_install \
+    && cd ../ && rm -rf gdrcopy
+
+ARG cassini_headers_ref=9a8a738a879f007849fbc69be8e3487a4abf0952
+RUN git clone https://github.com/HewlettPackard/shs-cassini-headers.git \
+    && cd shs-cassini-headers \
+    && git checkout ${cassini_headers_ref} \
+    && cp -r include/* /usr/include/ \
+    && cp -r share/* /usr/share/ \
+    && cd .. \
+    && rm -r shs-cassini-headers
+
+ARG cxi_driver_ref=af5d2ed4114134ea4eaf095d16af619573729045
+RUN git clone https://github.com/HewlettPackard/shs-cxi-driver.git \
+    && cd shs-cxi-driver \
+    && git checkout ${cxi_ddriver_ref} \
+    && cp -r include/* /usr/include/ \
+    && cd .. \
+    && rm -r shs-cxi-driver
+
+ARG libcxi_ref=3a33b3966d2898ab129458c8813b0cbcdcec06f5
+RUN git clone https://github.com/HewlettPackard/shs-libcxi.git \
+    && cd shs-libcxi \
+    && git checkout ${libcxi_ref} \
+    && ./autogen.sh \
+    && ./configure --prefix=/usr --with-cuda=/usr/local/cuda \
+    && make -j$(nproc) \
+    && make install \
+    && ldconfig \
+    && cd .. \
+    && rm -r shs-libcxi
+
+# Install libfabric
+ARG libfabric_version=2.0.0
+ARG libfabric_ref=c17230da527aada634e0cc50d9feafc83d7106ce
+# Libfabric 2.0.0 seems to have a bug preventing compilation of the CXI provider, using main branch for now
+RUN git clone --branch main --single-branch https://github.com/ofiwg/libfabric.git \
+    && cd libfabric \
+    && git checkout ${libfabric_ref} \
+    && ./autogen.sh \
+    && ./configure --prefix=/usr --with-cuda=/usr/local/cuda --enable-cuda-dlopen --enable-gdrcopy-dlopen --enable-cxi --enable-lnx --enable-efa \
+    && make -j$(nproc) \
+    && make install \
+    && ldconfig \
+    && cd .. \
+    && rm -rf libfabric
+
+# Install UCX
+ARG UCX_VERSION=1.18.0
+RUN wget https://github.com/openucx/ucx/releases/download/v${UCX_VERSION}/ucx-${UCX_VERSION}.tar.gz \
+    && tar xzf ucx-${UCX_VERSION}.tar.gz \
+    && cd ucx-${UCX_VERSION} \
+    && mkdir build \
+    && cd build \
+    && ../configure --prefix=/usr --with-cuda=/usr/local/cuda --with-gdrcopy=/usr/local --enable-mt --enable-devel-headers \
+    && make -j$(nproc) \
+    && make install \
+    && cd ../.. \
+    && rm -rf ucx-${UCX_VERSION}.tar.gz ucx-${UCX_VERSION}

--- a/examples/container/cxi-base/README.md
+++ b/examples/container/cxi-base/README.md
@@ -1,0 +1,29 @@
+# CXI base container for HPE Slingshot connectivity
+
+This image provides foundational libraries and frameworks to build HPC software and applications with support for the HPE Slingshot high-speed network and CUDA GPUs.
+
+Slingshot connectivity is enabled through user-space CXI software components, which in turn allow interaction with the Cassini NICs.
+
+This image is not intended to be used on its own, but to serve as a base to build higher-level software (e.g. MPI implementations) and application stacks.
+
+Builds of the image are currently hosted on the Quay.io registry at https://quay.io/repository/ethcscs/cxi-base.
+
+## Contents
+
+- CUDA 12.8.0 (including other dependencies like CUDNN and NCCL from the NVIDIA Docker Hub image)
+- GDRCopy 2.4.4
+- Libfabric (commit c17230da527aada634e0cc50d9feafc83d7106ce) with the following providers explicitly enabled:
+    - CXI
+    - AWS EFA
+    - LINKx
+- UCX 1.18.0
+- HPE Cassini headers (commit 9a8a738a879f007849fbc69be8e3487a4abf0952)
+- HPE CXI driver (commit af5d2ed4114134ea4eaf095d16af619573729045)
+- HPE libcxi (commit 3a33b3966d2898ab129458c8813b0cbcdcec06f5)
+
+## Notes
+
+- This image and its derivatives are self-sufficient with respect to Slingshot connectivity, and do not require hooks to inject a custom CXI stack from the host.
+- The libfabric EFA provider is included to leave open the possibility to experiment with derived images on AWS infrastructure as well.
+- The libfabric LINKx provider is included to allow for experimentation.
+- Although only the libfabric framework and its CXI provider are required to support the Slingshot network, this image also packages the UCX communication framework to allow building a broader set of software (e.g. some OpenSHMEM implementations) and supporting optimized Infiniband communication as well.

--- a/examples/container/nv-hpc-bench/Containerfile
+++ b/examples/container/nv-hpc-bench/Containerfile
@@ -32,30 +32,36 @@ RUN apt-get update \
         --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-ARG GDRCOPY_VER=2.4.4
-RUN git clone --depth 1 -b v${GDRCOPY_VER} https://github.com/NVIDIA/gdrcopy.git && \
-    cd gdrcopy && \
-    export CUDA_PATH=${CUDA_HOME:-$(echo $(which nvcc) | grep -o '.*cuda')} && \
-    make CC=gcc CUDA=$CUDA_PATH lib && \
-    make lib_install && \
-    cd ../ && rm -rf gdrcopy
 
-RUN git clone --depth 1 https://github.com/HewlettPackard/shs-cassini-headers.git \
+ARG GDRCOPY_VER=2.4.4
+RUN git clone --depth 1 --branch v${GDRCOPY_VER} https://github.com/NVIDIA/gdrcopy.git \
+    && cd gdrcopy \
+    && export CUDA_PATH=${CUDA_HOME:-$(echo $(which nvcc) | grep -o '.*cuda')} \
+    && make CC=gcc CUDA=$CUDA_PATH lib \
+    && make lib_install \
+    && cd ../ && rm -rf gdrcopy
+
+ARG cassini_headers_ref=9a8a738a879f007849fbc69be8e3487a4abf0952
+RUN git clone https://github.com/HewlettPackard/shs-cassini-headers.git \
     && cd shs-cassini-headers \
+    && git checkout ${cassini_headers_ref} \
     && cp -r include/* /usr/include/ \
     && cp -r share/* /usr/share/ \
     && cd .. \
     && rm -r shs-cassini-headers
 
-RUN git clone --depth 1 https://github.com/HewlettPackard/shs-cxi-driver.git \
+ARG cxi_driver_ref=af5d2ed4114134ea4eaf095d16af619573729045
+RUN git clone https://github.com/HewlettPackard/shs-cxi-driver.git \
     && cd shs-cxi-driver \
+    && git checkout ${cxi_ddriver_ref} \
     && cp -r include/* /usr/include/ \
     && cd .. \
     && rm -r shs-cxi-driver
 
-RUN git clone --depth 1 https://github.com/HewlettPackard/shs-libcxi.git \
+ARG libcxi_ref=3a33b3966d2898ab129458c8813b0cbcdcec06f5
+RUN git clone https://github.com/HewlettPackard/shs-libcxi.git \
     && cd shs-libcxi \
-    && git checkout release/shs-12.0 \
+    && git checkout ${libcxi_ref} \
     && ./autogen.sh \
     && ./configure --prefix=/usr --with-cuda=/usr/local/cuda \
     && make -j$(nproc) \
@@ -65,10 +71,12 @@ RUN git clone --depth 1 https://github.com/HewlettPackard/shs-libcxi.git \
     && rm -r shs-libcxi
 
 # Install libfabric
+ARG libfabric_version=2.0.0
+ARG libfabric_ref=c17230da527aada634e0cc50d9feafc83d7106ce
 # Libfabric 2.0.0 seems to have a bug preventing compilation of the CXI provider, using main branch for now
-ARG libfabric_version=main
-RUN git clone --depth 1 --branch ${libfabric_version} https://github.com/ofiwg/libfabric.git \
+RUN git clone --branch main --single-branch https://github.com/ofiwg/libfabric.git \
     && cd libfabric \
+    && git checkout ${libfabric_ref} \
     && ./autogen.sh \
     && ./configure --prefix=/usr --with-cuda=/usr/local/cuda --enable-cuda-dlopen --enable-gdrcopy-dlopen --enable-cxi --enable-lnx --enable-efa \
     && make -j$(nproc) \

--- a/examples/container/nv-hpc-bench/Containerfile
+++ b/examples/container/nv-hpc-bench/Containerfile
@@ -98,7 +98,7 @@ RUN wget https://github.com/openucx/ucx/releases/download/v${UCX_VERSION}/ucx-${
     && rm -rf ucx-${UCX_VERSION}.tar.gz ucx-${UCX_VERSION}
 
 # Install OpenMPI
-ARG OMPI_VER=5.0.6
+ARG OMPI_VER=5.0.7
 RUN wget -q https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-${OMPI_VER}.tar.gz \
     && tar xf openmpi-${OMPI_VER}.tar.gz \
     && cd openmpi-${OMPI_VER} \

--- a/examples/container/nv-hpc-bench/Containerfile
+++ b/examples/container/nv-hpc-bench/Containerfile
@@ -1,8 +1,5 @@
 FROM docker.io/nvidia/cuda:12.8.0-devel-ubuntu24.04
 
-ARG OMPI_VER=5.0.6
-ARG GDRCOPY_VER=2.4.4
-
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \
        apt-get install -y \
@@ -23,7 +20,6 @@ RUN apt-get update \
         numactl \
         libconfig-dev \
         libuv1-dev \
-        libucx-dev \
         libfuse-dev \
         libfuse3-dev \
         libyaml-dev \
@@ -36,6 +32,7 @@ RUN apt-get update \
         --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
+ARG GDRCOPY_VER=2.4.4
 RUN git clone --depth 1 -b v${GDRCOPY_VER} https://github.com/NVIDIA/gdrcopy.git && \
     cd gdrcopy && \
     export CUDA_PATH=${CUDA_HOME:-$(echo $(which nvcc) | grep -o '.*cuda')} && \
@@ -80,11 +77,25 @@ RUN git clone --depth 1 --branch ${libfabric_version} https://github.com/ofiwg/l
     && cd .. \
     && rm -rf libfabric
 
+# Install UCX
+ARG UCX_VERSION=1.18.0
+RUN wget https://github.com/openucx/ucx/releases/download/v${UCX_VERSION}/ucx-${UCX_VERSION}.tar.gz \
+    && tar xzf ucx-${UCX_VERSION}.tar.gz \
+    && cd ucx-${UCX_VERSION} \
+    && mkdir build \
+    && cd build \
+    && ../configure --prefix=/usr --with-cuda=/usr/local/cuda --with-gdrcopy=/usr/local --enable-mt --enable-devel-headers \
+    && make -j$(nproc) \
+    && make install \
+    && cd ../.. \
+    && rm -rf ucx-${UCX_VERSION}.tar.gz ucx-${UCX_VERSION}
+
 # Install OpenMPI
+ARG OMPI_VER=5.0.6
 RUN wget -q https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-${OMPI_VER}.tar.gz \
     && tar xf openmpi-${OMPI_VER}.tar.gz \
     && cd openmpi-${OMPI_VER} \
-    && ./configure --with-ofi=/usr --with-gdrcopy=/usr/local --prefix=/usr --with-cxi --with-slingshot --enable-oshmem \
+    && ./configure --prefix=/usr --with-ofi=/usr --with-ucx=/usr --with-gdrcopy=/usr/local --with-cxi --with-slingshot --enable-oshmem \
        --with-cuda=/usr/local/cuda --with-cuda-libdir=/usr/local/cuda/lib64/stubs \
     && make -j$(nproc) \
     && make install \

--- a/examples/container/nv-hpc-bench/Containerfile
+++ b/examples/container/nv-hpc-bench/Containerfile
@@ -32,7 +32,6 @@ RUN apt-get update \
         --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-
 ARG GDRCOPY_VER=2.4.4
 RUN git clone --depth 1 --branch v${GDRCOPY_VER} https://github.com/NVIDIA/gdrcopy.git \
     && cd gdrcopy \

--- a/examples/container/nv-hpc-bench/Containerfile.short
+++ b/examples/container/nv-hpc-bench/Containerfile.short
@@ -1,0 +1,52 @@
+FROM quay.io/ethcscs/ompi:5.0.7
+
+# Download pre-built benchmarks package
+RUN wget -q --progress=bar:force https://developer.download.nvidia.com/compute/nvidia-hpc-benchmarks/redist/nvidia_hpc_benchmarks_openmpi/linux-sbsa/nvidia_hpc_benchmarks_openmpi-linux-sbsa-24.09.02-archive.tar.xz \
+    && tar xf nvidia_hpc_benchmarks_openmpi-linux-sbsa-24.09.02-archive.tar.xz \
+    && mv nvidia_hpc_benchmarks_openmpi-linux-sbsa-24.09.02-archive nvidia_hpc_benchmarks \
+    && rm nvidia_hpc_benchmarks_openmpi-linux-sbsa-24.09.02-archive.tar.xz
+
+# Build NVSHMEM from source
+RUN wget -q https://developer.download.nvidia.com/compute/redist/nvshmem/2.11.0/source/nvshmem_src_2.11.0-5.txz \
+    && tar -xvJf nvshmem_src_2.11.0-5.txz \
+    && cd nvshmem_src_2.11.0-5 \
+    && NVSHMEM_DEBUG=0 \
+       NVSHMEM_DEVEL=0 \
+       NVSHMEM_DEFAULT_PMI2=0 \
+       NVSHMEM_DEFAULT_PMIX=0 \
+       NVSHMEM_DISABLE_COLL_POLL=1 \
+       NVSHMEM_ENABLE_ALL_DEVICE_INLINING=0 \
+       NVSHMEM_GPU_COLL_USE_LDST=0 \
+       NVSHMEM_LIBFABRIC_SUPPORT=1 \
+       NVSHMEM_MPI_SUPPORT=1 \
+       NVSHMEM_MPI_IS_OMPI=1 \
+       NVSHMEM_NVTX=1 \
+       NVSHMEM_PMIX_SUPPORT=1 \
+       NVSHMEM_SHMEM_SUPPORT=1 \
+       NVSHMEM_TEST_STATIC_LIB=0 \
+       NVSHMEM_TIMEOUT_DEVICE_POLLING=0 \
+       NVSHMEM_TRACE=0 \
+       NVSHMEM_USE_DLMALLOC=0 \
+       NVSHMEM_USE_NCCL=1 \
+       NVSHMEM_USE_GDRCOPY=1 \
+       NVSHMEM_VERBOSE=0 \
+       NVSHMEM_DEFAULT_UCX=0 \
+       NVSHMEM_UCX_SUPPORT=0 \
+       NVSHMEM_IBGDA_SUPPORT=0 \
+       NVSHMEM_IBGDA_SUPPORT_GPUMEM_ONLY=0 \
+       NVSHMEM_IBDEVX_SUPPORT=0 \
+       NVSHMEM_IBRC_SUPPORT=0 \
+       LIBFABRIC_HOME=/usr \
+       NCCL_HOME=/usr \
+       GDRCOPY_HOME=/usr/local \
+       MPI_HOME=/usr \
+       SHMEM_HOME=/usr \
+       cmake . \
+       && make -j$(nproc) \
+       && make install
+
+# Replace pre-built NVSHMEM shipped with the benchmarks with the one we just built
+RUN rm -r /nvidia_hpc_benchmarks/lib/nvshmem \
+    && cp -R /usr/local/nvshmem/lib /nvidia_hpc_benchmarks/lib/nvshmem
+
+WORKDIR /nvidia_hpc_benchmarks

--- a/examples/container/nv-hpc-bench/README.md
+++ b/examples/container/nv-hpc-bench/README.md
@@ -5,10 +5,13 @@ Self-sufficient container image with pre-compiled [NVIDIA HPC Benchmarks](https:
 ## Notes
 
 - The image does not require hooks to inject a custom CXI stack from the host
-- Running a container reuires a hook for bridging the PMIx interface between host and container
-- The image installs UCX from the package manager so that OpenSHMEM can be built. OpenSHMEM is in turn a dependency for NVSHMEM
+- Running a container requires a hook for bridging the PMIx interface between host and container
+- The image installs the UCX communication framework so that OpenSHMEM can be built. OpenSHMEM is in turn a dependency for NVSHMEM
 - NVSHMEM is rebuilt from source because the build bundled with the benchmarks incurs in a segmentation fault when using its libfabric backend; NVSHMEM 2.11.0 is used instead of more recent 3.x releases to respect the dynamic linking by benchmark executables
 - The image includes also the libfabric LINKx provider for experimentation.
+- Two variants of the Containerfile are provided:
+    1. An extended one with explicit build instructions for all the software components besides CUDA.
+    2. A short one using other images from this Git repository as base, for a more modular approach.
 
 
 ## Examples

--- a/examples/container/ompi/Containerfile
+++ b/examples/container/ompi/Containerfile
@@ -1,0 +1,13 @@
+FROM quay.io/ethcscs/cxi-base:20250305
+
+ARG OMPI_VER=5.0.7
+RUN wget -q https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-${OMPI_VER}.tar.gz \
+    && tar xf openmpi-${OMPI_VER}.tar.gz \
+    && cd openmpi-${OMPI_VER} \
+    && ./configure --prefix=/usr --with-ofi=/usr --with-ucx=/usr --with-gdrcopy=/usr/local --with-cxi --with-slingshot --enable-oshmem \
+       --with-cuda=/usr/local/cuda --with-cuda-libdir=/usr/local/cuda/lib64/stubs \
+    && make -j$(nproc) \
+    && make install \
+    && ldconfig \
+    && cd .. \
+    && rm -rf openmpi-${OMPI_VER}.tar.gz openmpi-${OMPI_VER}

--- a/examples/container/ompi/README.md
+++ b/examples/container/ompi/README.md
@@ -1,0 +1,7 @@
+# OpenMPI container with HPE Slingshot support
+
+Container image providing OpenMPI 5 with CUDA and CXI (i.e. HPE Slingshot) support. Intended to be used as base to build HPC application stacks.
+
+Builds of the image are currently hosted on the Quay.io registry at https://quay.io/repository/ethcscs/ompi.
+
+Please refer to the CXI base container image for a more detailed overview of the software available in this image.

--- a/examples/container/osu-mpich/Containerfile
+++ b/examples/container/osu-mpich/Containerfile
@@ -1,7 +1,4 @@
-FROM docker.io/nvidia/cuda:12.6.3-devel-ubuntu24.04
-
-ARG MPI_VER=4.2.1
-ARG GDRCOPY_VER=2.3
+FROM docker.io/nvidia/cuda:12.8.0-devel-ubuntu24.04
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \
@@ -33,29 +30,35 @@ RUN apt-get update \
         --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone --depth 1 -b v${GDRCOPY_VER} https://github.com/NVIDIA/gdrcopy.git && \
-    cd gdrcopy && \
-    export CUDA_PATH=${CUDA_HOME:-$(echo $(which nvcc) | grep -o '.*cuda')} && \
-    make CC=gcc CUDA=$CUDA_PATH lib && \
-    make lib_install && \
-    cd ../ && rm -rf gdrcopy
+ARG GDRCOPY_VER=2.4.4
+RUN git clone --depth 1 --branch v${GDRCOPY_VER} https://github.com/NVIDIA/gdrcopy.git \
+    && cd gdrcopy \
+    && export CUDA_PATH=${CUDA_HOME:-$(echo $(which nvcc) | grep -o '.*cuda')} \
+    && make CC=gcc CUDA=$CUDA_PATH lib \
+    && make lib_install \
+    && cd ../ && rm -rf gdrcopy
 
-RUN git clone --depth 1 https://github.com/HewlettPackard/shs-cassini-headers.git \
+ARG cassini_headers_ref=9a8a738a879f007849fbc69be8e3487a4abf0952
+RUN git clone https://github.com/HewlettPackard/shs-cassini-headers.git \
     && cd shs-cassini-headers \
+    && git checkout ${cassini_headers_ref} \
     && cp -r include/* /usr/include/ \
     && cp -r share/* /usr/share/ \
     && cd .. \
     && rm -r shs-cassini-headers
 
-RUN git clone --depth 1 https://github.com/HewlettPackard/shs-cxi-driver.git \
+ARG cxi_driver_ref=af5d2ed4114134ea4eaf095d16af619573729045
+RUN git clone https://github.com/HewlettPackard/shs-cxi-driver.git \
     && cd shs-cxi-driver \
+    && git checkout ${cxi_ddriver_ref} \
     && cp -r include/* /usr/include/ \
     && cd .. \
     && rm -r shs-cxi-driver
 
-RUN git clone --depth 1 https://github.com/HewlettPackard/shs-libcxi.git \
+ARG libcxi_ref=3a33b3966d2898ab129458c8813b0cbcdcec06f5
+RUN git clone https://github.com/HewlettPackard/shs-libcxi.git \
     && cd shs-libcxi \
-    && git checkout release/shs-12.0 \
+    && git checkout ${libcxi_ref} \
     && ./autogen.sh \
     && ./configure --prefix=/usr --with-cuda=/usr/local/cuda \
     && make -j$(nproc) \
@@ -65,10 +68,12 @@ RUN git clone --depth 1 https://github.com/HewlettPackard/shs-libcxi.git \
     && rm -r shs-libcxi
 
 # Install libfabric
+ARG libfabric_version=2.0.0
+ARG libfabric_ref=c17230da527aada634e0cc50d9feafc83d7106ce
 # Libfabric 2.0.0 seems to have a bug preventing compilation of the CXI provider, using main branch for now
-ARG libfabric_version=main
-RUN git clone --depth 1 --branch ${libfabric_version} https://github.com/ofiwg/libfabric.git \
+RUN git clone --branch main --single-branch https://github.com/ofiwg/libfabric.git \
     && cd libfabric \
+    && git checkout ${libfabric_ref} \
     && ./autogen.sh \
     && ./configure --prefix=/usr --with-cuda=/usr/local/cuda --enable-cuda-dlopen --enable-gdrcopy-dlopen --enable-cxi --enable-lnx --enable-efa \
     && make -j$(nproc) \
@@ -77,6 +82,7 @@ RUN git clone --depth 1 --branch ${libfabric_version} https://github.com/ofiwg/l
     && cd .. \
     && rm -rf libfabric
 
+ARG MPI_VER=4.2.1
 RUN wget -q https://www.mpich.org/static/downloads/${MPI_VER}/mpich-${MPI_VER}.tar.gz \
     && tar xf mpich-${MPI_VER}.tar.gz \
     && cd mpich-${MPI_VER} \

--- a/examples/container/osu-ompi/Containerfile
+++ b/examples/container/osu-ompi/Containerfile
@@ -82,7 +82,7 @@ RUN git clone --branch main --single-branch https://github.com/ofiwg/libfabric.g
     && cd .. \
     && rm -rf libfabric
 
-ARG OMPI_VER=5.0.6
+ARG OMPI_VER=5.0.7
 RUN wget -q  https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-${OMPI_VER}.tar.gz \
     && tar xf openmpi-${OMPI_VER}.tar.gz \
     && cd openmpi-${OMPI_VER} \

--- a/examples/container/osu-ompi/Containerfile
+++ b/examples/container/osu-ompi/Containerfile
@@ -47,7 +47,7 @@ RUN git clone https://github.com/HewlettPackard/shs-cassini-headers.git \
     && cd .. \
     && rm -r shs-cassini-headers
 
-ARG cxi_driver_ref=caa8bf41a25817111f137bb7e8be1e45c4e6758f
+ARG cxi_driver_ref=af5d2ed4114134ea4eaf095d16af619573729045
 RUN git clone https://github.com/HewlettPackard/shs-cxi-driver.git \
     && cd shs-cxi-driver \
     && git checkout ${cxi_ddriver_ref} \
@@ -55,7 +55,7 @@ RUN git clone https://github.com/HewlettPackard/shs-cxi-driver.git \
     && cd .. \
     && rm -r shs-cxi-driver
 
-ARG libcxi_ref=31a183b521d1da670574e2a1bf59a91cb579b105
+ARG libcxi_ref=3a33b3966d2898ab129458c8813b0cbcdcec06f5
 RUN git clone https://github.com/HewlettPackard/shs-libcxi.git \
     && cd shs-libcxi \
     && git checkout ${libcxi_ref} \
@@ -69,7 +69,7 @@ RUN git clone https://github.com/HewlettPackard/shs-libcxi.git \
 
 # Install libfabric
 ARG libfabric_version=2.0.0
-ARG libfabric_ref=36b974dc27c67fd0268e0ab575fd01592f756992
+ARG libfabric_ref=c17230da527aada634e0cc50d9feafc83d7106ce
 # Libfabric 2.0.0 seems to have a bug preventing compilation of the CXI provider, using main branch for now
 RUN git clone --branch main --single-branch https://github.com/ofiwg/libfabric.git \
     && cd libfabric \

--- a/examples/container/osu-ompi/Containerfile.short
+++ b/examples/container/osu-ompi/Containerfile.short
@@ -1,0 +1,17 @@
+FROM quay.io/ethcscs/ompi:5.0.7
+
+RUN wget -q http://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.5.tar.gz \
+    && tar xf osu-micro-benchmarks-7.5.tar.gz \
+    && cd osu-micro-benchmarks-7.5 \
+    && ldconfig /usr/local/cuda/targets/sbsa-linux/lib/stubs \
+    && ./configure --prefix=/usr/local CC=$(which mpicc) CFLAGS="-O3 -lcuda -lnvidia-ml" \
+                   --enable-cuda --with-cuda-include=/usr/local/cuda/include \
+                   --with-cuda-libpath=/usr/local/cuda/lib64 \
+                   CXXFLAGS="-lmpi -lcuda" \ 
+    && make -j$(nproc) \
+    && make install \
+    && ldconfig \
+    && cd .. \
+    && rm -rf osu-micro-benchmarks-7.5 osu-micro-benchmarks-7.5.tar.gz
+
+WORKDIR /usr/local/libexec/osu-micro-benchmarks/mpi

--- a/examples/container/osu-ompi/README.md
+++ b/examples/container/osu-ompi/README.md
@@ -5,8 +5,11 @@ Self-sufficient container image with OSU Micro-Benchmarks built on OpenMPI 5 wit
 ## Notes (see also EDF TOML for reference)
 - The image does not require hooks to inject a custom CXI stack from the host
 - Interaction with host PMIx needs to be understood better: environment variables for PSEC and GDS parameters have to be set on Alps to prevent warnings and crashes due to missing components
-- Running a container reuires a hook for bridging the PMIx interface between host and container
+- Running a container requires a hook for bridging the PMIx interface between host and container
 - The image includes also the libfabric LINKx provider for experimentation.
+- Two variants of the Containerfile are provided:
+    1. An extended one with explicit build instructions for all the software components besides CUDA.
+    2. A short one using other images from this Git repository as base, for a more modular approach.
 
 ## Examples
 


### PR DESCRIPTION
- All Containerfiles use fixed versions or git refs for software built from source, in particular CXI components
- All versions and git refs have been updated and verified to result in working software (rebuilt and tested all 3 application images on Alps)
- Started breaking down monolithic images in more modular pieces:
  - A general base image with common frameworks and libs (e.g. CUDA, CXI, OFI, UCX)
  - An OpenMPI image built on top of the CXI base
- Added short variants of Containerfiles for application examples based on OpenMPI, leveraging the new "modular" images as base